### PR TITLE
Adding BUS Sel and MonitorOnSel

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,10 @@ The following methods are available
 - `SetMute(val bool)`
 - `Mono() bool`
 - `SetMono(val bool)`
+- `Sel() bool`
+- `SetSel(val bool)`
+- `Monitor() bool`
+- `SetMonitor(val bool)`
 - `Label() string`
 - `SetLabel(val string)`
 - `Gain() float64`

--- a/bus.go
+++ b/bus.go
@@ -12,6 +12,10 @@ type iBus interface {
 	SetMute(val bool)
 	Mono() bool
 	SetMono(val bool)
+	Sel() bool
+	SetSel(val bool)
+	Monitor() bool
+	SetMonitor(val bool)
 	Label() string
 	SetLabel(val string)
 	Gain() float64
@@ -49,6 +53,26 @@ func (b *bus) Mono() bool {
 // SetMono sets the value of the Mute parameter
 func (b *bus) SetMono(val bool) {
 	b.setter_bool("Mono", val)
+}
+
+// Sel returns the value of the Sel parameter
+func (b *bus) Sel() bool {
+	return b.getter_bool("Sel")
+}
+
+// SetSel sets the alue of the Sel parameter
+func (b *bus) SetSel(val bool) {
+	b.setter_bool("Sel", val)
+}
+
+// Monitor returns the value of the Monitor parameter
+func (b *bus) Monitor() bool {
+	return b.getter_bool("Monitor")
+}
+
+// SetMonitor sets the alue of the Monitor parameter
+func (b *bus) SetMonitor(val bool) {
+	b.setter_bool("Monitor", val)
 }
 
 // Label returns the value of the MC parameter


### PR DESCRIPTION
The BUS Sel and MonitorOnSel properties are required if we want to properly use VoiceMeeter as a matrix; 

- Sel is use to "Select" a BUS so that, when changing Strip volume, it does so only for the selected BUS. 

- MonitorOnSel is used so that, when "Selecting" a BUS for the purpose of editing other strip volumes, the BUS that has the MonitorOnSel activated will replicate the matrix of volume strips from the "Selected" bus;

ie: BUS A1 = Speakers ; BUS A2 = Headphones; If we enable "MonitorOnSel" on A2 and then "Sel" A1, the audio levels of the strips will match what is configured for BUS A1. 